### PR TITLE
Added Gui functionality for viewing and running dijkstra's algorithm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,8 +12,8 @@ results/
 .project
 .cproject
 
-# Object files
-*.o
+# Object and dependency files
+build/
 
 # Resources
 resources/

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ gui.log
 /gui
 /worldGen
 /dijkstra
+
+# makefile dependency file
+makefile.deps

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 # World files
 worlds/
 
+# Result files
+results/
+
 # Eclipse files
 .settings/
 .project

--- a/includes/algorithms/tools/PathTile.h
+++ b/includes/algorithms/tools/PathTile.h
@@ -12,6 +12,7 @@
 #include <limits>
 
 #include "common/World.h"
+#include "common/Point.h"
 
 typedef unsigned int uint;
 
@@ -25,7 +26,7 @@ public:
     const uint INF = std::numeric_limits<uint>::max();
 
     PathTile ();
-    PathTile (World::tile_t tile, uint x, uint y);
+    PathTile (World::tile_t tile, const Point& xy);
     PathTile (const PathTile& other);
     virtual ~PathTile ();
 
@@ -34,27 +35,23 @@ public:
     void setTile (World::tile_t tile);
     World::tile_t getTile () const;
 
+    Point xy () const;
+
     void setBestCost (uint bestCost);
     uint getBestCost () const;
 
-    uint x () const;
-    uint y () const;
-
-    uint bestX () const;
-    uint bestY () const;
-    void setBestTile (uint x, uint y);
+    Point bestTile () const;
+    void setBestTile (const Point& tile_xy);
 
     bool operator< (const PathTile& rhs) const;
     bool operator>=(const PathTile& rhs) const;
 
 private:
     World::tile_t m_tile;
-    uint m_bestCost;
-    uint m_x;
-    uint m_y;
+    Point m_xy;
 
-    uint m_bestX;
-    uint m_bestY;
+    uint m_bestCost;
+    Point m_bestTile;
 };
 
 } /* namespace pathFind */

--- a/includes/algorithms/tools/PriorityQueue.h
+++ b/includes/algorithms/tools/PriorityQueue.h
@@ -34,10 +34,11 @@ public:
     PathTile top () const;
 
     void changeBestCost (uint x, uint y, uint bestCost);
+    void tryUpdateBestCost (uint target_x, uint target_y, const PathTile& bestTile);
 
     bool isValid (uint x, uint y) const;
     // Assumes that user already checked that (x, y) is valid
-    PathTile& getPathTile (uint x, uint y) const;
+    PathTile getPathTile (uint x, uint y) const;
 
 private:
 

--- a/includes/common/Point.h
+++ b/includes/common/Point.h
@@ -1,0 +1,38 @@
+/**
+ * File        : Point.h
+ * Description : Holds a simple point data struct for holding a 2D position
+ *               in world coordinates
+ */
+
+#ifndef POINT_H
+#define POINT_H
+
+typedef unsigned int uint;
+
+namespace pathFind
+{
+
+struct Point
+{
+    uint x, y;
+    Point (uint x, uint y)
+        : x (x), y (y)
+    {
+    }
+
+    Point (const Point& other)
+        : x (other.x), y (other.y)
+    {
+    }
+
+    Point& operator= (const Point& rhs)
+    {
+        x = rhs.x;
+        y = rhs.y;
+        return *this;
+    }
+};
+
+} /* namespace pathFind */
+
+#endif /* POINT_H */

--- a/includes/common/Point.h
+++ b/includes/common/Point.h
@@ -19,18 +19,6 @@ struct Point
         : x (x), y (y)
     {
     }
-
-    Point (const Point& other)
-        : x (other.x), y (other.y)
-    {
-    }
-
-    Point& operator= (const Point& rhs)
-    {
-        x = rhs.x;
-        y = rhs.y;
-        return *this;
-    }
 };
 
 } /* namespace pathFind */

--- a/includes/common/Results.h
+++ b/includes/common/Results.h
@@ -1,0 +1,45 @@
+/**
+ * File        : Results.h
+ * Description : A few functions that read and write path result files as well
+ *               as path performance files
+ */
+
+#ifndef RESULTS_H
+#define RESULTS_H
+
+#include <iostream>
+#include <vector>
+#include <string>
+#include <sstream>
+#include <fstream>
+
+#include <boost/filesystem.hpp>
+
+#include "common/Point.h"
+
+namespace pathFind
+{
+
+const std::string RESULTS_DIR = "results";
+const std::string RESULTS_EXT = ".res";
+
+void writeResults (const std::vector<Point>& path, const std::string& worldName,
+                   const std::string& algName)
+{
+    std::stringstream dirName;
+    dirName << RESULTS_DIR << "/" << worldName << "_"
+            << path.back ().x << "_" << path.back ().y << "_"
+            << path.front ().x << "_" << path.front ().y;
+    boost::filesystem::create_directory(dirName.str ());
+
+    std::ofstream resultFile (dirName.str () + "/" + algName + RESULTS_EXT);
+    resultFile << path.size() << std::endl;
+    for (auto ri = path.rbegin(); ri != path.rend(); ++ri)
+    {
+        resultFile << ri->x << " " << ri->y << std::endl;
+    }
+}
+
+} /* namespace pathFind */
+
+#endif /* RESULTS_H */

--- a/includes/common/Results.h
+++ b/includes/common/Results.h
@@ -40,6 +40,35 @@ void writeResults (const std::vector<Point>& path, const std::string& worldName,
     }
 }
 
+void readResults (std::vector<Point>& path, const std::string& worldName,
+                  const std::string& algName)
+{
+    std::stringstream fileName;
+    fileName << RESULTS_DIR << "/" << worldName << "_"
+             << path.back ().x << "_" << path.back ().y << "_"
+             << path.front ().x << "_" << path.front ().y
+             << "/" << algName << RESULTS_EXT;
+
+    std::ifstream resultFile (fileName.str ());
+    if (!resultFile)
+    {
+        std::cout << "Failed to open file: " << fileName.str () << std::endl;
+        return;
+    }
+
+    uint size;
+    resultFile >> size;
+
+    path.reserve (size);
+
+    for (uint i = 0; i < size; ++i)
+    {
+        uint x, y;
+        resultFile >> x >> y;
+        path.emplace_back (x, y);
+    }
+}
+
 } /* namespace pathFind */
 
 #endif /* RESULTS_H */

--- a/includes/common/Results.h
+++ b/includes/common/Results.h
@@ -24,11 +24,50 @@ const std::string RESULTS_DIR = "results";
 const std::string RESULTS_EXT = ".res";
 
 void writeResults (const std::vector<Point>& path, const std::string& worldName,
-                   const std::string& algName);
+                   const std::string& algName)
+{
+    std::stringstream dirName;
+    dirName << RESULTS_DIR << "/" << worldName << "_"
+            << path.back ().x << "_" << path.back ().y << "_"
+            << path.front ().x << "_" << path.front ().y;
+    boost::filesystem::create_directory(dirName.str ());
 
-void readResults (std::vector<Point>& path, const Point& start, const Point& end,
-                  const std::string& worldName, const std::string& algName);
+    std::ofstream resultFile (dirName.str () + "/" + algName + RESULTS_EXT);
+    resultFile << path.size() << std::endl;
+    for (auto ri = path.rbegin(); ri != path.rend(); ++ri)
+    {
+        resultFile << ri->x << " " << ri->y << std::endl;
+    }
+}
 
+void readResults (std::vector<Point>& path, const std::string& worldName,
+                  const std::string& algName)
+{
+    std::stringstream fileName;
+    fileName << RESULTS_DIR << "/" << worldName << "_"
+             << path.back ().x << "_" << path.back ().y << "_"
+             << path.front ().x << "_" << path.front ().y
+             << "/" << algName << RESULTS_EXT;
+
+    std::ifstream resultFile (fileName.str ());
+    if (!resultFile)
+    {
+        std::cout << "Failed to open file: " << fileName.str () << std::endl;
+        return;
+    }
+
+    uint size;
+    resultFile >> size;
+
+    path.reserve (size);
+
+    for (uint i = 0; i < size; ++i)
+    {
+        uint x, y;
+        resultFile >> x >> y;
+        path.emplace_back (x, y);
+    }
+}
 } /* namespace pathFind */
 
 #endif /* RESULTS_H */

--- a/includes/common/Results.h
+++ b/includes/common/Results.h
@@ -23,7 +23,7 @@ namespace pathFind
 const std::string RESULTS_DIR = "results";
 const std::string RESULTS_EXT = ".res";
 
-void writeResults (const std::vector<Point>& path, const std::string& worldName,
+inline void writeResults (const std::vector<Point>& path, const std::string& worldName,
                    const std::string& algName)
 {
     std::stringstream dirName;
@@ -40,7 +40,7 @@ void writeResults (const std::vector<Point>& path, const std::string& worldName,
     }
 }
 
-void readResults (std::vector<Point>& path, const std::string& worldName,
+inline void readResults (std::vector<Point>& path, const std::string& worldName,
                   const std::string& algName)
 {
     std::stringstream fileName;

--- a/includes/common/Results.h
+++ b/includes/common/Results.h
@@ -24,7 +24,7 @@ const std::string RESULTS_DIR = "results";
 const std::string RESULTS_EXT = ".res";
 
 inline void writeResults (const std::vector<Point>& path, const std::string& worldName,
-                   const std::string& algName)
+                          const std::string& algName)
 {
     std::stringstream dirName;
     dirName << RESULTS_DIR << "/" << worldName << "_"
@@ -40,13 +40,13 @@ inline void writeResults (const std::vector<Point>& path, const std::string& wor
     }
 }
 
-inline void readResults (std::vector<Point>& path, const std::string& worldName,
-                  const std::string& algName)
+inline void readResults (std::vector<Point>& path, const Point& start, const Point& end,
+                         const std::string& worldName, const std::string& algName)
 {
     std::stringstream fileName;
     fileName << RESULTS_DIR << "/" << worldName << "_"
-             << path.back ().x << "_" << path.back ().y << "_"
-             << path.front ().x << "_" << path.front ().y
+             << start.x << "_" << start.y << "_"
+             << end.x << "_" << end.y
              << "/" << algName << RESULTS_EXT;
 
     std::ifstream resultFile (fileName.str ());

--- a/includes/common/Results.h
+++ b/includes/common/Results.h
@@ -24,50 +24,10 @@ const std::string RESULTS_DIR = "results";
 const std::string RESULTS_EXT = ".res";
 
 void writeResults (const std::vector<Point>& path, const std::string& worldName,
-                   const std::string& algName)
-{
-    std::stringstream dirName;
-    dirName << RESULTS_DIR << "/" << worldName << "_"
-            << path.back ().x << "_" << path.back ().y << "_"
-            << path.front ().x << "_" << path.front ().y;
-    boost::filesystem::create_directory(dirName.str ());
+                   const std::string& algName);
 
-    std::ofstream resultFile (dirName.str () + "/" + algName + RESULTS_EXT);
-    resultFile << path.size() << std::endl;
-    for (auto ri = path.rbegin(); ri != path.rend(); ++ri)
-    {
-        resultFile << ri->x << " " << ri->y << std::endl;
-    }
-}
-
-void readResults (std::vector<Point>& path, const std::string& worldName,
-                  const std::string& algName)
-{
-    std::stringstream fileName;
-    fileName << RESULTS_DIR << "/" << worldName << "_"
-             << path.back ().x << "_" << path.back ().y << "_"
-             << path.front ().x << "_" << path.front ().y
-             << "/" << algName << RESULTS_EXT;
-
-    std::ifstream resultFile (fileName.str ());
-    if (!resultFile)
-    {
-        std::cout << "Failed to open file: " << fileName.str () << std::endl;
-        return;
-    }
-
-    uint size;
-    resultFile >> size;
-
-    path.reserve (size);
-
-    for (uint i = 0; i < size; ++i)
-    {
-        uint x, y;
-        resultFile >> x >> y;
-        path.emplace_back (x, y);
-    }
-}
+void readResults (std::vector<Point>& path, const Point& start, const Point& end,
+                  const std::string& worldName, const std::string& algName);
 
 } /* namespace pathFind */
 

--- a/includes/gui/GraphicTile.h
+++ b/includes/gui/GraphicTile.h
@@ -20,7 +20,7 @@ namespace pathFind
 namespace gui
 {
 
-
+const SDL_Color DEFAULT_COLOR = {0xFF, 0xFF, 0xFF, 0xFF};
 
 class GraphicTile
 {

--- a/includes/gui/GraphicTile.h
+++ b/includes/gui/GraphicTile.h
@@ -40,6 +40,7 @@ public:
     SDL_Rect getRect () const;
     World::tile_t getTile () const;
 
+    SDL_Color getRectColor () const;
     void setRectColor (SDL_Color color);
 
     void render (SDL_Renderer* renderer, SDL_Texture* texture);

--- a/includes/gui/GraphicTile.h
+++ b/includes/gui/GraphicTile.h
@@ -20,6 +20,8 @@ namespace pathFind
 namespace gui
 {
 
+
+
 class GraphicTile
 {
 public:
@@ -37,6 +39,8 @@ public:
 
     SDL_Rect getRect () const;
     World::tile_t getTile () const;
+
+    void setRectColor (SDL_Color color);
 
     void render (SDL_Renderer* renderer, SDL_Texture* texture);
 

--- a/includes/gui/WorldViewport.h
+++ b/includes/gui/WorldViewport.h
@@ -36,10 +36,10 @@ public:
     virtual void setWorld (const std::string& worldFileName);
     virtual void loadWorld ();
 
-    /*virtual void loadResults (const Point& start, const Point& end,
+    virtual void loadResults (const Point& start, const Point& end,
                              const std::string& algName);
     virtual void setResultsEnabled (bool resultsEnabled);
-*/
+
     virtual uint getCameraX () const;
     virtual uint getCameraY () const;
     virtual uint getTileScale () const;

--- a/includes/gui/WorldViewport.h
+++ b/includes/gui/WorldViewport.h
@@ -50,8 +50,12 @@ public:
 
     virtual void setTextEnabled (bool textEnabled);
 
+    virtual void setShowEndPoints (bool showEndPoints);
+
 protected:
-    uint getIndex (uint x, uint y) const;
+    enum Mode {VIEW, SELECT};
+
+    Mode m_mode;
 
     std::string m_worldName;
     std::vector<GraphicTile> m_gTiles;
@@ -68,13 +72,29 @@ protected:
     std::vector<Point> m_results;
     bool m_resultsEnabled;
 
+    bool m_showEndPoints;
+    Point m_start;
+    Point m_end;
+
     SDL_Texture* m_textTextures[256];
+    SDL_Texture* m_startTexture;
+    SDL_Texture* m_endTexture;
 
-    uint getCameraOppX () const;
-    uint getCameraOppY () const;
+    virtual void setMode (Mode mode);
 
-    void initializeTextures (SDL_Renderer* renderer);
-    void destroyResources ();
+    virtual bool trySelectTile (int mouseX, int mouseY, Point& tile);
+
+    uint getIndex (uint x, uint y) const;
+
+    virtual uint getCameraOppX () const;
+    virtual uint getCameraOppY () const;
+
+    virtual void resetEndPoints ();
+
+    virtual void initializeTextures (SDL_Renderer* renderer);
+    virtual void initializeTexture (SDL_Renderer* renderer, SDL_Texture*& texture,
+                                    const std::string& text);
+    virtual void destroyResources ();
 };
 
 } /* namespace gui */

--- a/includes/gui/WorldViewport.h
+++ b/includes/gui/WorldViewport.h
@@ -76,15 +76,19 @@ protected:
     Point m_start;
     Point m_end;
 
+    SDL_Color m_startPrevColor;
+    SDL_Color m_endPrevColor;
+
     SDL_Texture* m_textTextures[256];
     SDL_Texture* m_startTexture;
     SDL_Texture* m_endTexture;
 
     virtual void setMode (Mode mode);
 
-    virtual bool trySelectTile (int mouseX, int mouseY, Point& tile);
+    virtual Point trySelectTile (int mouseX, int mouseY);
 
     uint getIndex (uint x, uint y) const;
+    bool isNull (const Point& p) const;
 
     virtual uint getCameraOppX () const;
     virtual uint getCameraOppY () const;

--- a/includes/gui/WorldViewport.h
+++ b/includes/gui/WorldViewport.h
@@ -10,6 +10,8 @@
 #include <string>
 
 #include "common/World.h"
+#include "common/Point.h"
+#include "common/Results.h"
 #include "gui/Error.h"
 #include "gui/Viewport.h"
 #include "gui/GraphicTile.h"
@@ -31,9 +33,13 @@ public:
 
     virtual void handleEvent (SDL_Event& e);
 
-    virtual void setWorld (std::string worldFileName);
+    virtual void setWorld (const std::string& worldFileName);
     virtual void loadWorld ();
 
+    /*virtual void loadResults (const Point& start, const Point& end,
+                             const std::string& algName);
+    virtual void setResultsEnabled (bool resultsEnabled);
+*/
     virtual uint getCameraX () const;
     virtual uint getCameraY () const;
     virtual uint getTileScale () const;
@@ -58,6 +64,9 @@ protected:
 
     bool m_textEnabled;
     bool m_textInitialized;
+
+    std::vector<Point> m_results;
+    bool m_resultsEnabled;
 
     SDL_Texture* m_textTextures[256];
 

--- a/includes/gui/WorldViewport.h
+++ b/includes/gui/WorldViewport.h
@@ -31,8 +31,8 @@ public:
 
     virtual void handleEvent (SDL_Event& e);
 
-    virtual void setFile (std::string worldFileName);
-    virtual void loadFile ();
+    virtual void setWorld (std::string worldFileName);
+    virtual void loadWorld ();
 
     virtual uint getCameraX () const;
     virtual uint getCameraY () const;
@@ -47,7 +47,7 @@ public:
 protected:
     uint getIndex (uint x, uint y) const;
 
-    std::string m_worldFileName;
+    std::string m_worldName;
     std::vector<GraphicTile> m_gTiles;
     size_t m_worldWidth;
     size_t m_worldHeight;

--- a/makefile
+++ b/makefile
@@ -6,7 +6,8 @@ LDLIBS                = -lboost_system -lboost_filesystem
 LDFLAGS		          =
 
 # Files that all programs depend on
-COMMON_SRCS           = src/common/World.cc
+COMMON_SRCS           = src/common/World.cc \
+                        src/common/Results.cc
 COMMON_HEADERS        = includes/common/World.h \
                         includes/common/Point.h \
                         includes/common/Results.h

--- a/makefile
+++ b/makefile
@@ -7,13 +7,14 @@ LDFLAGS		          =
 
 # Files that all programs depend on
 COMMON_SRCS           = src/common/World.cc
-COMMON_HEADERS        = includes/common/World.h
+COMMON_HEADERS        = includes/common/World.h \
+                        includes/common/Point.h
 
 # Files that all path finding algorithms depend on
 COMMON_ALG_SRCS       = src/algorithms/tools/PathTile.cc \
                         src/algorithms/tools/PriorityQueue.cc
 COMMON_ALG_HEADERS    = includes/algorithms/tools/PriorityQueue.h \
-                        includes/algorithms/tools/PathTile.cc
+                        includes/algorithms/tools/PathTile.h
 
 
 # Graphical program
@@ -59,9 +60,10 @@ dijkstra_OBJS         = $(patsubst %.cc,%.o,$(filter %.cc,$(dijkstra_SRCS)))
 all: $(TARGETS)
 
 .SECONDEXPANSION:
-$(TARGETS): $$($$@_OBJS)
-	$(CXX) $(LDFLAGS) $^ -o $@  $(LDLIBS) $($@_LIBS)
+$(TARGETS): $$($$@_OBJS) $$($$@_HEADERS)
+	$(CXX) $(LDFLAGS) $($@_OBJS) -o $@  $(LDLIBS) $($@_LIBS)
 
+$(foreach target, $(TARGETS), $($(target)_HEADERS)):
 
 .PHONY : clean
 clean:

--- a/makefile
+++ b/makefile
@@ -2,13 +2,14 @@
 CXX		              = g++
 CXXFLAGS              = -Wall -std=c++14
 CPPFLAGS              = -Iincludes
-LDLIBS                =
+LDLIBS                = -lboost_system -lboost_filesystem
 LDFLAGS		          =
 
 # Files that all programs depend on
 COMMON_SRCS           = src/common/World.cc
 COMMON_HEADERS        = includes/common/World.h \
-                        includes/common/Point.h
+                        includes/common/Point.h \
+                        includes/common/Results.h
 
 # Files that all path finding algorithms depend on
 COMMON_ALG_SRCS       = src/algorithms/tools/PathTile.cc \
@@ -73,3 +74,7 @@ clean:
 .PHONY : clean_worlds
 clean_worlds:
 	rm -f worlds/*
+
+.PHONY : clean_results
+clean_results:
+	rm -f -r results/*

--- a/makefile
+++ b/makefile
@@ -4,32 +4,18 @@ CXXFLAGS              = -Wall -std=c++14
 CPPFLAGS              = -Iincludes
 LDLIBS                = -lboost_system -lboost_filesystem
 LDFLAGS		          =
+SRCSUFFIX          = .cc
 
 # Files that all programs depend on
-COMMON_SRCS           = src/common/World.cc \
-                        src/common/Results.cc
-COMMON_HEADERS        = includes/common/World.h \
-                        includes/common/Point.h \
-                        includes/common/Results.h
+COMMON_SRCS           = src/common/World.cc
 
 # Files that all path finding algorithms depend on
 COMMON_ALG_SRCS       = src/algorithms/tools/PathTile.cc \
                         src/algorithms/tools/PriorityQueue.cc
-COMMON_ALG_HEADERS    = includes/algorithms/tools/PriorityQueue.h \
-                        includes/algorithms/tools/PathTile.h
-
 
 # Graphical program
 TARGETS              += gui
 gui_LIBS              = -lSDL2 -lSDL2_ttf
-gui_HEADERS           = $(COMMON_HEADERS) \
-                        includes/gui/Error.h \
-                        includes/gui/Window.h \
-                        includes/gui/Viewport.h \
-                        includes/gui/Button.h \
-                        includes/gui/TextInput.h \
-                        includes/gui/WorldViewport.h \
-                        includes/gui/GraphicTile.h
 gui_SRCS              = $(COMMON_SRCS) \
                         src/gui/Gui.cc \
                         src/gui/Error.cc \
@@ -39,37 +25,39 @@ gui_SRCS              = $(COMMON_SRCS) \
                         src/gui/TextInput.cc \
                         src/gui/WorldViewport.cc \
                         src/gui/GraphicTile.cc
-gui_OBJS              = $(patsubst %.cc,%.o,$(filter %.cc,$(gui_SRCS)))
+gui_OBJS              = $(patsubst %$(SRCSUFFIX),%.o,$(filter %$(SRCSUFFIX),$(gui_SRCS)))
 
 # World generation program
 TARGETS              += worldGen
-worldGen_HEADERS      = $(COMMON_HEADERS)
 worldGen_SRCS         = $(COMMON_SRCS) \
                         src/worldGen/WorldGen.cc
-worldGen_OBJS         = $(patsubst %.cc,%.o,$(filter %.cc,$(worldGen_SRCS)))
+worldGen_OBJS         = $(patsubst %$(SRCSUFFIX),%.o,$(filter %$(SRCSUFFIX),$(worldGen_SRCS)))
 
 # Djikstra's algorithm
 TARGETS              += dijkstra
-dijkstra_HEADERS      = $(COMMON_HEADERS) \
-                        $(COMMON_ALG_HEADERS)
 dijkstra_SRCS         = $(COMMON_SRCS) \
                         $(COMMON_ALG_SRCS) \
                         src/algorithms/dijkstra/Dijkstra.cc
-dijkstra_OBJS         = $(patsubst %.cc,%.o,$(filter %.cc,$(dijkstra_SRCS))) 
+dijkstra_OBJS         = $(patsubst %$(SRCSUFFIX),%.o,$(filter %$(SRCSUFFIX),$(dijkstra_SRCS))) 
 
+MAKEDEPENDS           = $(CXX) $(CPPFLAGS) $(CXXFLAGS) -MM -MP
+
+SRCS                  = $(foreach target,$(TARGETS),$(sort $($(target)_SRCS)))
 
 .PHONY : all
 all: $(TARGETS)
 
 .SECONDEXPANSION:
-$(TARGETS): $$($$@_OBJS) $$($$@_HEADERS)
-	$(CXX) $(LDFLAGS) $($@_OBJS) -o $@  $(LDLIBS) $($@_LIBS)
+$(TARGETS): $$($$@_OBJS)
+	$(CXX) $(LDFLAGS) $^ -o $@  $(LDLIBS) $($@_LIBS)
 
-$(foreach target, $(TARGETS), $($(target)_HEADERS)):
+#$(foreach target, $(TARGETS), $($(target)_HEADERS)):
+
+-include makefile.deps
 
 .PHONY : clean
 clean:
-	rm -f $(foreach target,$(TARGETS),$(sort $($(target)_OBJS))) \
+	rm -f $(patsubst %$(SRCSUFFIX),%.o,$(SRCS)) \
 	      $(TARGETS) gui.log
 
 .PHONY : clean_worlds
@@ -79,3 +67,7 @@ clean_worlds:
 .PHONY : clean_results
 clean_results:
 	rm -f -r results/*
+
+.PHONY : makefile.deps
+makefile.deps :
+	$(MAKEDEPENDS) $(SRCS) > makefile.deps

--- a/src/algorithms/dijkstra/Dijkstra.cc
+++ b/src/algorithms/dijkstra/Dijkstra.cc
@@ -23,9 +23,6 @@ const std::string WORLD_EXT = ".world";
 
 const std::string RESULTS_DIR = "results";
 
-void updateNeighbor (PriorityQueue& pq, const PathTile& tile,
-                     uint neighborX, uint neighborY);
-
 int main (int args, char* argv[])
 {
     // Program should be started with 5 command line parameter
@@ -82,15 +79,15 @@ int main (int args, char* argv[])
 
     std::unordered_map<uint, PathTile> expandedTiles;
     PathTile tile = openTiles.top();
-    while (tile.x () != endX || tile.y () != endY)
+    while (tile.xy ().x != endX || tile.xy ().y != endY)
     {
         openTiles.pop ();
         expandedTiles[tile.getTile ().id] = tile;
         // Check each neighbor
-        updateNeighbor (openTiles, tile, tile.x () + 1, tile.y ()); // east
-        updateNeighbor (openTiles, tile, tile.x (), tile.y () + 1); // south
-        updateNeighbor (openTiles, tile, tile.x () - 1, tile.y ()); // west
-        updateNeighbor (openTiles, tile, tile.x (), tile.y () - 1); // north
+        openTiles.tryUpdateBestCost (tile.xy ().x + 1, tile.xy ().y, tile); // east
+        openTiles.tryUpdateBestCost (tile.xy ().x, tile.xy ().y + 1, tile); // south
+        openTiles.tryUpdateBestCost (tile.xy ().x - 1, tile.xy ().y, tile); // west
+        openTiles.tryUpdateBestCost (tile.xy ().x, tile.xy ().y - 1, tile); // north
 
         tile = openTiles.top ();
     }
@@ -118,26 +115,12 @@ int main (int args, char* argv[])
     std::cout << "filename: " << resultsFilename.str () << std::endl;
 
     std::ofstream resultFile (resultsFilename.str ());
-    while (tile.x () != startX || tile.y () != startY)
+
+    while (tile.xy ().x != startX || tile.xy ().y != startY)
     {
-        std::cout << "x: " << tile.x () << " y: " << tile.y () << std::endl;
-        tile = expandedTiles[(tile.bestY () * world.getWidth()) + tile.bestX ()];
+        std::cout << "x: " << tile.xy ().x << " y: " << tile.xy ().y << std::endl;
+        tile = expandedTiles[(tile.bestTile ().y * world.getWidth()) + tile.bestTile ().x];
     }
 
     return EXIT_SUCCESS;
-}
-
-void updateNeighbor (PriorityQueue& pq, const PathTile& tile,
-                     uint neighborX, uint neighborY)
-{
-    if (pq.isValid (neighborX, neighborY))
-    {
-        PathTile& neighborTile = pq.getPathTile (neighborX, neighborY);
-        uint totalCost = tile.getBestCost() + neighborTile.getTile().cost;
-        if (totalCost < neighborTile.getBestCost())
-        {
-            neighborTile.setBestTile(tile.x (), tile.y ());
-            pq.changeBestCost(neighborX, neighborY, totalCost);
-        }
-    }
 }

--- a/src/algorithms/tools/PathTile.cc
+++ b/src/algorithms/tools/PathTile.cc
@@ -12,31 +12,25 @@ namespace pathFind
 {
 
 PathTile::PathTile ()
-    : m_bestCost (INF),
-      m_x (0),
-      m_y (0),
-      m_bestX (0),
-      m_bestY (0)
+    : m_xy (0, 0),
+      m_bestCost (INF),
+      m_bestTile (0, 0)
 {
 }
 
-PathTile::PathTile (World::tile_t tile, uint x, uint y)
+PathTile::PathTile (World::tile_t tile, const Point& xy)
     : m_tile (tile),
+      m_xy (xy.x, xy.y),
       m_bestCost (INF),
-      m_x (x),
-      m_y (y),
-      m_bestX (x),
-      m_bestY (y)
+      m_bestTile (xy.x, xy.y)
 {
 }
 
 PathTile::PathTile (const PathTile& other)
     : m_tile (other.m_tile),
+      m_xy (other.m_xy.x, other.m_xy.y),
       m_bestCost (other.m_bestCost),
-      m_x (other.m_x),
-      m_y (other.m_y),
-      m_bestX (other.m_bestX),
-      m_bestY (other.m_bestY)
+      m_bestTile (other.m_bestTile.x, other.m_bestTile.y)
 {
 }
 
@@ -50,10 +44,8 @@ PathTile& PathTile::operator= (const PathTile& rhs)
     {
         m_tile = rhs.m_tile;
         m_bestCost = rhs.m_bestCost;
-        m_x = rhs.m_x;
-        m_y = rhs.m_y;
-        m_bestX = rhs.m_bestX;
-        m_bestY = rhs.m_bestY;
+        m_xy = rhs.m_xy;
+        m_bestTile = rhs.m_bestTile;
     }
     return *this;
 }
@@ -68,6 +60,11 @@ World::tile_t PathTile::getTile () const
     return m_tile;
 }
 
+Point PathTile::xy () const
+{
+    return m_xy;
+}
+
 void PathTile::setBestCost (uint bestCost)
 {
     m_bestCost = bestCost;
@@ -78,30 +75,14 @@ uint PathTile::getBestCost () const
     return m_bestCost;
 }
 
-uint PathTile::x () const
+Point PathTile::bestTile () const
 {
-    return m_x;
+    return m_bestTile;
 }
 
-uint PathTile::y () const
+void PathTile::setBestTile (const Point& tile_xy)
 {
-    return m_y;
-}
-
-uint PathTile::bestX () const
-{
-    return m_bestX;
-}
-
-uint PathTile::bestY () const
-{
-    return m_bestY;
-}
-
-void PathTile::setBestTile (uint x, uint y)
-{
-    m_bestX = x;
-    m_bestY = y;
+    m_bestTile = tile_xy;
 }
 
 bool PathTile::operator< (const PathTile& rhs) const

--- a/src/algorithms/tools/PriorityQueue.cc
+++ b/src/algorithms/tools/PriorityQueue.cc
@@ -20,7 +20,7 @@ PriorityQueue::PriorityQueue(const World& world)
             if (t.cost != 0)
             {
                 m_heap.emplace_back (std::make_shared<handle_t>(
-                        PathTile{t, x, y}, m_heap.size ()));
+                        PathTile{t, {x, y}}, m_heap.size ()));
                 m_hashTable[t.id] = m_heap.back ();
             }
         }
@@ -63,7 +63,7 @@ PathTile PriorityQueue::top () const
     return m_heap[0]->tile;
 }
 
-void PriorityQueue::changeBestCost (uint x, uint y, uint bestCost)
+void PriorityQueue::changeBestCost(uint x, uint y, uint bestCost)
 {
     auto handle = getHandle (x, y);
     if (handle != nullptr)
@@ -73,13 +73,27 @@ void PriorityQueue::changeBestCost (uint x, uint y, uint bestCost)
     }
 }
 
+void PriorityQueue::tryUpdateBestCost (uint target_x, uint target_y, const PathTile& bestTile)
+{
+    auto targetHandle = getHandle (target_x, target_y);
+    if (targetHandle != nullptr)
+    {
+        uint totalCost = bestTile.getBestCost() + targetHandle->tile.getTile().cost;
+        if (totalCost < targetHandle->tile.getBestCost())
+        {
+            targetHandle->tile.setBestTile (bestTile.xy ());
+            targetHandle->tile.setBestCost(totalCost);
+            upHeap (targetHandle->index);
+        }
+    }
+}
+
 bool PriorityQueue::isValid (uint x, uint y) const
 {
     return getHandle (x, y) != nullptr;
 }
 
-PathTile&
-PriorityQueue::getPathTile (uint x, uint y) const
+PathTile PriorityQueue::getPathTile (uint x, uint y) const
 {
     return getHandle(x, y)->tile;
 }

--- a/src/gui/Error.cc
+++ b/src/gui/Error.cc
@@ -28,7 +28,7 @@ void Log::logInfo (std::string message)
 Log::Log ()
         : m_errOut (LOG_FILE_NAME)
 {
-    m_errOut << "Logging initialized." << std::endl;
+    m_errOut << "Logging initialized." << std::endl << std::flush;
 }
 
 Log& Log::get ()
@@ -39,16 +39,16 @@ Log& Log::get ()
 
 void Log::_logError (std::string message)
 {
-    m_errOut << ERROR_PREFIX << LOG_SEPARATOR << message << std::endl;
+    m_errOut << ERROR_PREFIX << LOG_SEPARATOR << message << std::endl << std::flush;
 }
 
 void Log::_logWarning (std::string message)
 {
-    m_errOut << WARNING_PREFIX << LOG_SEPARATOR << message << std::endl;
+    m_errOut << WARNING_PREFIX << LOG_SEPARATOR << message << std::endl << std::flush;
 }
 
 void Log::_logInfo (std::string message)
 {
-    m_errOut << INFO_PREFIX << LOG_SEPARATOR << message << std::endl;
+    m_errOut << INFO_PREFIX << LOG_SEPARATOR << message << std::endl << std::flush;
 }
 

--- a/src/gui/GraphicTile.cc
+++ b/src/gui/GraphicTile.cc
@@ -86,6 +86,11 @@ World::tile_t GraphicTile::getTile () const
     return m_tileData;
 }
 
+SDL_Color GraphicTile::getRectColor () const
+{
+    return m_rectColor;
+}
+
 void GraphicTile::setRectColor(SDL_Color color)
 {
     m_rectColor = color;

--- a/src/gui/GraphicTile.cc
+++ b/src/gui/GraphicTile.cc
@@ -23,7 +23,7 @@ GraphicTile::GraphicTile (World::tile_t tileData, SDL_Rect rect)
     }
     else
     {
-        m_rectColor = {0xFF, 0xFF, 0xFF, 0xFF};
+        m_rectColor = DEFAULT_COLOR;
         m_textColor = {0x00, 0x00, 0x00, 0xFF};
     }
 }

--- a/src/gui/GraphicTile.cc
+++ b/src/gui/GraphicTile.cc
@@ -86,6 +86,11 @@ World::tile_t GraphicTile::getTile () const
     return m_tileData;
 }
 
+void GraphicTile::setRectColor(SDL_Color color)
+{
+    m_rectColor = color;
+}
+
 void GraphicTile::render (SDL_Renderer* renderer, SDL_Texture* texture)
 {
     SDL_SetRenderDrawColor (renderer, m_rectColor.r, m_rectColor.g,

--- a/src/gui/Gui.cc
+++ b/src/gui/Gui.cc
@@ -99,7 +99,6 @@ int main (int args, char* argv[])
                 mainViewport->disable();
             });
 
-
     auto regenerate_B = std::make_shared<gui::Button> (
             toolbarViewport->getX (), toolbarViewport->getY (),
             "Regenerate World", SDL_Rect
@@ -118,10 +117,35 @@ int main (int args, char* argv[])
             [&]()
             {
                 mainViewport->enable ();
+                //worldViewport->setResultsEnabled(false);
                 worldViewport->disable ();
                 toolbarViewport->disable ();
             });
+/*
+    std::shared_ptr<gui::TextInput> viewResult_TI;
 
+    std::shared_ptr<gui::Button> viewResult_B = std::make_shared<gui::Button> (
+            toolbarViewport->getX (), toolbarViewport->getY (),
+            "View Results", SDL_Rect
+            {420, toolbarViewport->getHeight () / 2 - 25, 280, 50}, 16,
+            [&]()
+            {
+                viewResult_TI->enable();
+                viewResult_B->disable();
+            });
+
+    viewResult_TI = std::make_shared<gui::TextInput> (
+            560, toolbarViewport->getHeight () / 2 - 25, 16,
+            [&](std::string s)
+            {
+                std::stringstream input (s);
+                uint sx, sy, ex, ey;
+                input >> sx >> sy >> ex >> ey;
+                worldViewport->loadResults({sx, sy}, {ex, ey}, "djisktra");
+                worldViewport->setResultsEnabled(true);
+                viewResult_B->enable ();
+            });
+*/
     mainViewport->addButton (genWorld_B);
     mainViewport->addButton (genWorldInput_TI);
     genWorld_B->enable ();
@@ -133,8 +157,11 @@ int main (int args, char* argv[])
 
     toolbarViewport->addButton (regenerate_B);
     toolbarViewport->addButton (backToMenu_B);
+    //toolbarViewport->addButton (viewResult_B);
+    //toolbarViewport->addButton (viewResult_TI);
     backToMenu_B->enable ();
     regenerate_B->enable ();
+    //viewResult_B->enable ();
 
     window.addViewport (mainViewport);
     window.addViewport (worldViewport);

--- a/src/gui/Gui.cc
+++ b/src/gui/Gui.cc
@@ -117,17 +117,17 @@ int main (int args, char* argv[])
             [&]()
             {
                 mainViewport->enable ();
-                //worldViewport->setResultsEnabled(false);
+                worldViewport->setResultsEnabled(false);
                 worldViewport->disable ();
                 toolbarViewport->disable ();
             });
-/*
+
     std::shared_ptr<gui::TextInput> viewResult_TI;
 
     std::shared_ptr<gui::Button> viewResult_B = std::make_shared<gui::Button> (
             toolbarViewport->getX (), toolbarViewport->getY (),
             "View Results", SDL_Rect
-            {420, toolbarViewport->getHeight () / 2 - 25, 280, 50}, 16,
+            {620, toolbarViewport->getHeight () / 2 - 25, 280, 50}, 16,
             [&]()
             {
                 viewResult_TI->enable();
@@ -135,17 +135,17 @@ int main (int args, char* argv[])
             });
 
     viewResult_TI = std::make_shared<gui::TextInput> (
-            560, toolbarViewport->getHeight () / 2 - 25, 16,
+            920, toolbarViewport->getHeight () / 2 - 25, 16,
             [&](std::string s)
             {
                 std::stringstream input (s);
                 uint sx, sy, ex, ey;
                 input >> sx >> sy >> ex >> ey;
-                worldViewport->loadResults({sx, sy}, {ex, ey}, "djisktra");
+                worldViewport->loadResults({sx, sy}, {ex, ey}, "dijkstra");
                 worldViewport->setResultsEnabled(true);
                 viewResult_B->enable ();
             });
-*/
+
     mainViewport->addButton (genWorld_B);
     mainViewport->addButton (genWorldInput_TI);
     genWorld_B->enable ();
@@ -157,11 +157,11 @@ int main (int args, char* argv[])
 
     toolbarViewport->addButton (regenerate_B);
     toolbarViewport->addButton (backToMenu_B);
-    //toolbarViewport->addButton (viewResult_B);
-    //toolbarViewport->addButton (viewResult_TI);
+    toolbarViewport->addButton (viewResult_B);
+    toolbarViewport->addButton (viewResult_TI);
     backToMenu_B->enable ();
     regenerate_B->enable ();
-    //viewResult_B->enable ();
+    viewResult_B->enable ();
 
     window.addViewport (mainViewport);
     window.addViewport (worldViewport);

--- a/src/gui/Gui.cc
+++ b/src/gui/Gui.cc
@@ -54,6 +54,8 @@ int main (int args, char* argv[])
                 genWorldInput_TI->enable();
             });
 
+    std::shared_ptr<gui::Button> regenerate_B;
+
     std::string worldCommand;
     std::function<void(std::string)> genWorldFunct = [&](std::string s)
             {
@@ -70,8 +72,8 @@ int main (int args, char* argv[])
 
                 worldViewport->enable();
                 toolbarViewport->enable();
+                regenerate_B->enable ();
                 mainViewport->disable();
-                //sizeInput_TI->enable();
             };
 
     genWorldInput_TI = std::make_shared<gui::TextInput> (
@@ -87,6 +89,8 @@ int main (int args, char* argv[])
                 viewWorldInput_TI->enable ();
             });
 
+    std::shared_ptr<gui::Button> viewResult_B;
+
     viewWorldInput_TI = std::make_shared<gui::TextInput> (
             (SCREEN_WIDTH / 2), SCREEN_HEIGHT - 75, 16,
             [&](std::string s)
@@ -96,13 +100,28 @@ int main (int args, char* argv[])
 
                 worldViewport->enable();
                 toolbarViewport->enable();
+                viewResult_B->enable();
                 mainViewport->disable();
             });
 
-    auto regenerate_B = std::make_shared<gui::Button> (
+    auto backToMenu_B = std::make_shared<gui::Button> (
+            toolbarViewport->getX (), toolbarViewport->getY (),
+            "Back To Menu", SDL_Rect
+            {20, toolbarViewport->getHeight() / 2 - 25, 280, 50}, 16,
+            [&]()
+            {
+                mainViewport->enable ();
+                worldViewport->setResultsEnabled(false);
+                worldViewport->disable ();
+                viewResult_B->disable ();
+                regenerate_B->disable ();
+                toolbarViewport->disable ();
+            });
+
+    regenerate_B = std::make_shared<gui::Button> (
             toolbarViewport->getX (), toolbarViewport->getY (),
             "Regenerate World", SDL_Rect
-            {20, toolbarViewport->getHeight() / 2 - 25, 280, 50}, 16,
+            {320, toolbarViewport->getHeight() / 2 - 25, 280, 50}, 16,
             [&]()
             {
                 std::string command = "./worldGen " + worldCommand;
@@ -110,24 +129,13 @@ int main (int args, char* argv[])
 
                 worldViewport->loadWorld();
             });
-    auto backToMenu_B = std::make_shared<gui::Button> (
-            toolbarViewport->getX (), toolbarViewport->getY (),
-            "Back To Menu", SDL_Rect
-            {320, toolbarViewport->getHeight() / 2 - 25, 280, 50}, 16,
-            [&]()
-            {
-                mainViewport->enable ();
-                worldViewport->setResultsEnabled(false);
-                worldViewport->disable ();
-                toolbarViewport->disable ();
-            });
 
     std::shared_ptr<gui::TextInput> viewResult_TI;
 
-    std::shared_ptr<gui::Button> viewResult_B = std::make_shared<gui::Button> (
+    viewResult_B = std::make_shared<gui::Button> (
             toolbarViewport->getX (), toolbarViewport->getY (),
             "View Results", SDL_Rect
-            {620, toolbarViewport->getHeight () / 2 - 25, 280, 50}, 16,
+            {320, toolbarViewport->getHeight () / 2 - 25, 280, 50}, 16,
             [&]()
             {
                 viewResult_TI->enable();
@@ -135,7 +143,7 @@ int main (int args, char* argv[])
             });
 
     viewResult_TI = std::make_shared<gui::TextInput> (
-            920, toolbarViewport->getHeight () / 2 - 25, 16,
+            460, toolbarViewport->getHeight () / 2 - 25, 16,
             [&](std::string s)
             {
                 std::stringstream input (s);
@@ -160,8 +168,6 @@ int main (int args, char* argv[])
     toolbarViewport->addButton (viewResult_B);
     toolbarViewport->addButton (viewResult_TI);
     backToMenu_B->enable ();
-    regenerate_B->enable ();
-    viewResult_B->enable ();
 
     window.addViewport (mainViewport);
     window.addViewport (worldViewport);

--- a/src/gui/Gui.cc
+++ b/src/gui/Gui.cc
@@ -65,8 +65,8 @@ int main (int args, char* argv[])
                 int pos = worldName.find_first_of(" ");
                 worldName.erase(pos, std::string::npos);
 
-                worldViewport->setFile(worldName);
-                worldViewport->loadFile();
+                worldViewport->setWorld(worldName);
+                worldViewport->loadWorld();
 
                 worldViewport->enable();
                 toolbarViewport->enable();
@@ -91,8 +91,8 @@ int main (int args, char* argv[])
             (SCREEN_WIDTH / 2), SCREEN_HEIGHT - 75, 16,
             [&](std::string s)
             {
-                worldViewport->setFile(s);
-                worldViewport->loadFile();
+                worldViewport->setWorld(s);
+                worldViewport->loadWorld();
 
                 worldViewport->enable();
                 toolbarViewport->enable();
@@ -109,7 +109,7 @@ int main (int args, char* argv[])
                 std::string command = "./worldGen " + worldCommand;
                 system (command.c_str ());
 
-                worldViewport->loadFile();
+                worldViewport->loadWorld();
             });
     auto backToMenu_B = std::make_shared<gui::Button> (
             toolbarViewport->getX (), toolbarViewport->getY (),

--- a/src/gui/WorldViewport.cc
+++ b/src/gui/WorldViewport.cc
@@ -2,6 +2,7 @@
  * WorldViewport.cc
  */
 
+#include <iostream>
 #include <fstream>
 
 #include "gui/WorldViewport.h"
@@ -16,6 +17,8 @@ const uint MIN_TILE_SCALE = 5;
 const uint MAX_TILE_SCALE = 75;
 const uint DEFAULT_TILE_SCALE = 10;
 
+const SDL_Color DIJKSTRA_COLOR = {0x99, 0x99, 0x00, 0xFF};
+
 WorldViewport::WorldViewport (SDL_Rect rect, SDL_Color backgroundColor)
         : Viewport (rect, backgroundColor),
           m_worldName (" "),
@@ -25,7 +28,8 @@ WorldViewport::WorldViewport (SDL_Rect rect, SDL_Color backgroundColor)
           m_cameraY (0),
           m_tileScale (DEFAULT_TILE_SCALE),
           m_textEnabled (false),
-          m_textInitialized (false)
+          m_textInitialized (false),
+          m_resultsEnabled (false)
 {
     for (uint i = 0; i < 255; ++i)
     {
@@ -155,7 +159,7 @@ void WorldViewport::handleEvent (SDL_Event& e)
     }
 }
 
-void WorldViewport::setWorld (std::string worldName)
+void WorldViewport::setWorld (const std::string& worldName)
 {
     m_worldName = worldName;
 }
@@ -195,7 +199,23 @@ void WorldViewport::loadWorld ()
         }
     }
 }
+/*
+void WorldViewport::loadResults (const Point& start, const Point& end,
+                                const std::string& algName)
+{
+    readResults (m_results, start, end, m_worldName, algName);
+}
 
+void WorldViewport::setResultsEnabled (bool resultsEnabled)
+{
+    SDL_Color color = resultsEnabled ? SDL_Color{0x0F, 0xFF, 0xFF, 0xFF} :
+                                       SDL_Color {0xFF, 0xFF, 0xFF, 0xFF};
+    for (auto& r : m_results)
+    {
+        m_gTiles[getIndex (r.x, r.y)].setRectColor(color);
+    }
+}
+*/
 void WorldViewport::setCameraX (int x)
 {
     if (x < 0)
@@ -294,7 +314,9 @@ uint WorldViewport::getCameraOppY () const
 
 void WorldViewport::initializeTextures (SDL_Renderer* renderer)
 {
+    std::cout << "woo\n" << std::flush;
     destroyResources ();
+    std::cout << "wow\n" << std::flush;
     for (uint i = 0; i < 256; ++i)
     {
         std::string text = std::to_string (i);
@@ -321,6 +343,7 @@ void WorldViewport::initializeTextures (SDL_Renderer* renderer)
             return;
         }
     }
+    std::cout << "woo\n" << std::flush;
 
     m_textInitialized = true;
 

--- a/src/gui/WorldViewport.cc
+++ b/src/gui/WorldViewport.cc
@@ -18,7 +18,7 @@ const uint DEFAULT_TILE_SCALE = 10;
 
 WorldViewport::WorldViewport (SDL_Rect rect, SDL_Color backgroundColor)
         : Viewport (rect, backgroundColor),
-          m_worldFileName (" "),
+          m_worldName (" "),
           m_worldWidth (0),
           m_worldHeight (0),
           m_cameraX (0),
@@ -155,24 +155,24 @@ void WorldViewport::handleEvent (SDL_Event& e)
     }
 }
 
-void WorldViewport::setFile (std::string worldFileName)
+void WorldViewport::setWorld (std::string worldName)
 {
-    m_worldFileName = worldFileName;
+    m_worldName = worldName;
 }
 
-void WorldViewport::loadFile ()
+void WorldViewport::loadWorld ()
 {
     m_gTiles.clear();
     m_cameraX = 0;
     m_cameraY = 0;
 
-    std::string trueWorldName = "worlds/" + m_worldFileName + ".world";
-    Log::logInfo("Created world: " + trueWorldName);
-    std::ifstream worldFile(trueWorldName, std::ifstream::in | std::ifstream::binary);
+    std::string worldFileName = "worlds/" + m_worldName + ".world";
+    Log::logInfo("Created world: " + worldFileName);
+    std::ifstream worldFile(worldFileName, std::ifstream::in | std::ifstream::binary);
     if (!worldFile)
     {
         Log::logError ("WorldViewport either could not find or could not open "
-                + trueWorldName);
+                + worldFileName);
         return;
     }
 

--- a/src/gui/WorldViewport.cc
+++ b/src/gui/WorldViewport.cc
@@ -6,6 +6,7 @@
 #include <fstream>
 
 #include "gui/WorldViewport.h"
+#include "common/Results.h"
 
 namespace pathFind
 {
@@ -17,7 +18,8 @@ const uint MIN_TILE_SCALE = 5;
 const uint MAX_TILE_SCALE = 75;
 const uint DEFAULT_TILE_SCALE = 10;
 
-const SDL_Color DIJKSTRA_COLOR = {0x99, 0x99, 0x00, 0xFF};
+const SDL_Color SELECT_COLOR = {0xFF, 0x77, 0x00, 0xFF};
+const SDL_Color DIJKSTRA_COLOR = {0xFF, 0xF4, 0x7F, 0xFF};
 
 WorldViewport::WorldViewport (SDL_Rect rect, SDL_Color backgroundColor)
         : Viewport (rect, backgroundColor),
@@ -196,26 +198,27 @@ void WorldViewport::loadWorld ()
                               static_cast<int> (y * m_tileScale),
                               static_cast<int> (m_tileScale),
                               static_cast<int> (m_tileScale)});
+            m_gTiles.back().setTextEnabled(m_textEnabled);
         }
     }
 }
-/*
+
 void WorldViewport::loadResults (const Point& start, const Point& end,
                                 const std::string& algName)
 {
+    m_results.clear();
     readResults (m_results, start, end, m_worldName, algName);
 }
 
 void WorldViewport::setResultsEnabled (bool resultsEnabled)
 {
-    SDL_Color color = resultsEnabled ? SDL_Color{0x0F, 0xFF, 0xFF, 0xFF} :
-                                       SDL_Color {0xFF, 0xFF, 0xFF, 0xFF};
+    SDL_Color color = resultsEnabled ? DIJKSTRA_COLOR : DEFAULT_COLOR;
     for (auto& r : m_results)
     {
         m_gTiles[getIndex (r.x, r.y)].setRectColor(color);
     }
 }
-*/
+
 void WorldViewport::setCameraX (int x)
 {
     if (x < 0)
@@ -314,9 +317,7 @@ uint WorldViewport::getCameraOppY () const
 
 void WorldViewport::initializeTextures (SDL_Renderer* renderer)
 {
-    std::cout << "woo\n" << std::flush;
     destroyResources ();
-    std::cout << "wow\n" << std::flush;
     for (uint i = 0; i < 256; ++i)
     {
         std::string text = std::to_string (i);
@@ -343,7 +344,6 @@ void WorldViewport::initializeTextures (SDL_Renderer* renderer)
             return;
         }
     }
-    std::cout << "woo\n" << std::flush;
 
     m_textInitialized = true;
 


### PR DESCRIPTION
Also cleaned up some gui stuff.
Clicking Generate world now shows the regenerate button and back to menu button only, while clicking View World now shows the View Results button and back to menu button only.

You can start pathfinding by clicking on a non-wall tile and it will mark it with S and color it orange. Then if you click on another tile it wil do the same but mark it with E. Then if you hit enter, Dijkstra's algorithm is run from S to E and highlights the tiles it took yellow (and removes the Orange Highlight from your selection. If you click on two tiles for selection but then click again somwhere, it clears the selection you had.

Holding in alt while looking at results (with text enabled and assuming you aren't in mid selection of another pathfinding run) will mark the start and end tiles with S and E respectively so you can know which direction the algorithm was running.