### PR TITLE
Boosted performance of dijkstra and A*

### DIFF
--- a/includes/algorithms/tools/PriorityQueue.h
+++ b/includes/algorithms/tools/PriorityQueue.h
@@ -25,18 +25,25 @@ class PriorityQueue
 public:
 
     PriorityQueue () = delete;
+    PriorityQueue (size_t worldWidth, size_t worldHeight,
+                   std::function<uint (uint, uint)> heuristicFunction =
+                   [](uint, uint) { return 0; });
     PriorityQueue (const World& world,
             std::function<uint (uint, uint)> heuristicFunction =
                     [](uint, uint) { return 0; });
 
     ~PriorityQueue ();
 
-    void push (const PathTile& element);
+    void push (const World::tile_t& tile, const Point& xy, uint bestCost = PathTile::INF);
+    void push (const World::tile_t& tile, const Point& xy, uint bestCost,
+               const Point& bestTile);
+    void push (const PathTile& tile);
     void pop ();
     PathTile top () const;
 
     void changeBestCost (uint x, uint y, uint bestCost);
-    void tryUpdateBestCost (uint target_x, uint target_y, const PathTile& bestTile);
+    void tryUpdateBestCost (const World::tile_t& tile, const Point& targetXY,
+                            const PathTile& bestTile);
 
     bool isValid (uint x, uint y) const;
     // Assumes that user already checked that (x, y) is valid
@@ -72,6 +79,8 @@ private:
 
     std::vector<std::shared_ptr<handle_t>> m_heap;
     std::unordered_map<uint, std::shared_ptr<handle_t>> m_hashTable;
+
+    std::function <uint (uint, uint)> m_heurFunct;
 };
 
 } /* namespace parPath */

--- a/makefile
+++ b/makefile
@@ -1,6 +1,6 @@
 # Built-in Variables
 CXX		              = g++
-CXXFLAGS              = -Wall -std=c++14
+CXXFLAGS              = -Wall -g -std=c++14
 CPPFLAGS              = -Iincludes -MMD -MP
 LDLIBS                = -lboost_system -lboost_filesystem
 LDFLAGS		          =
@@ -45,7 +45,7 @@ dijkstra_SRCS         = $(COMMON_SRCS) \
                         src/algorithms/dijkstra/Dijkstra.cc
 dijkstra_OBJS         = $(dijkstra_SRCS:$(SRCFOLDER)/%.$(SRCSUFFIX)=$(OBJFOLDER)/%.o)
 
-TARGETS              += aStar
+#TARGETS              += aStar
 aStar_SRCS            = $(COMMON_SRCS) \
                         $(COMMON_ALG_SRCS) \
                         src/algorithms/aStar/AStar.cc

--- a/makefile
+++ b/makefile
@@ -45,7 +45,7 @@ dijkstra_SRCS         = $(COMMON_SRCS) \
                         src/algorithms/dijkstra/Dijkstra.cc
 dijkstra_OBJS         = $(dijkstra_SRCS:$(SRCFOLDER)/%.$(SRCSUFFIX)=$(OBJFOLDER)/%.o)
 
-#TARGETS              += aStar
+TARGETS              += aStar
 aStar_SRCS            = $(COMMON_SRCS) \
                         $(COMMON_ALG_SRCS) \
                         src/algorithms/aStar/AStar.cc

--- a/src/algorithms/aStar/AStar.cc
+++ b/src/algorithms/aStar/AStar.cc
@@ -69,27 +69,15 @@ int main (int args, char* argv[])
     auto t1 = std::chrono::high_resolution_clock::now();
 
     // Priority Queue with A* heuristic function added
-    PriorityQueue openTiles (world, [endX, endY] (uint x, uint y)
+    PriorityQueue openTiles (world.getWidth (), world.getHeight (),
+        [endX, endY] (uint x, uint y)
         {
             return  (x < endX ? endX - x : x - endX) +
                     (y < endY ? endY - y : y - endY);
         });
 
-    // Ensure that start and end points are valid
-    if (!openTiles.isValid (startX, startY))
-    {
-        std::cout << "Start point either is a wall or isn't out of the world bounds" << std::endl;
-        return EXIT_FAILURE;
-    }
-    // Check each neighbor
-    if (!openTiles.isValid (endX, endY))
-    {
-        std::cout << "End point either is a wall or isn't out of the world bounds" << std::endl;
-        return EXIT_FAILURE;
-    }
-
     // A* algorithm
-    openTiles.changeBestCost(startX, startY, 0);
+    openTiles.push (world (startX, startY), {startX, startY}, 0);
 
     std::unordered_map<uint, PathTile> expandedTiles;
     PathTile tile = openTiles.top();
@@ -98,10 +86,49 @@ int main (int args, char* argv[])
         openTiles.pop ();
         expandedTiles[tile.getTile ().id] = tile;
         // Check each neighbor
-        openTiles.tryUpdateBestCost (tile.xy ().x + 1, tile.xy ().y, tile); // east
-        openTiles.tryUpdateBestCost (tile.xy ().x, tile.xy ().y + 1, tile); // south
-        openTiles.tryUpdateBestCost (tile.xy ().x - 1, tile.xy ().y, tile); // west
-        openTiles.tryUpdateBestCost (tile.xy ().x, tile.xy ().y - 1, tile); // north
+        Point adjPoint {tile.xy ().x + 1, tile.xy ().y}; // east
+        if (adjPoint.x < world.getWidth() && adjPoint.y < world.getHeight ())
+        {
+            World::tile_t worldTile = world (adjPoint.x, adjPoint.y);
+            if (worldTile.cost != 0 &&
+                expandedTiles.find (worldTile.id) == expandedTiles.end ())
+            {
+                openTiles.tryUpdateBestCost (worldTile, adjPoint, tile);
+            }
+        }
+
+        adjPoint = {tile.xy ().x, tile.xy ().y + 1}; // south
+        if (adjPoint.x < world.getWidth() && adjPoint.y < world.getHeight ())
+        {
+            World::tile_t worldTile = world (adjPoint.x, adjPoint.y);
+            if (worldTile.cost != 0 &&
+                expandedTiles.find (worldTile.id) == expandedTiles.end ())
+            {
+                openTiles.tryUpdateBestCost (worldTile, adjPoint, tile);
+            }
+        }
+
+        adjPoint = {tile.xy ().x - 1, tile.xy ().y}; // west
+        if (adjPoint.x < world.getWidth() && adjPoint.y < world.getHeight ())
+        {
+            World::tile_t worldTile = world (adjPoint.x, adjPoint.y);
+            if (worldTile.cost != 0 &&
+                expandedTiles.find (worldTile.id) == expandedTiles.end ())
+            {
+                openTiles.tryUpdateBestCost (worldTile, adjPoint, tile);
+            }
+        }
+
+        adjPoint = {tile.xy ().x, tile.xy ().y - 1}; // north
+        if (adjPoint.x < world.getWidth() && adjPoint.y < world.getHeight ())
+        {
+            World::tile_t worldTile = world (adjPoint.x, adjPoint.y);
+            if (worldTile.cost != 0 &&
+                expandedTiles.find (worldTile.id) == expandedTiles.end ())
+            {
+                openTiles.tryUpdateBestCost (worldTile, adjPoint, tile);
+            }
+        }
 
         tile = openTiles.top ();
     }

--- a/src/algorithms/dijkstra/Dijkstra.cc
+++ b/src/algorithms/dijkstra/Dijkstra.cc
@@ -67,23 +67,10 @@ int main (int args, char* argv[])
 
     auto t1 = std::chrono::high_resolution_clock::now();
 
-    PriorityQueue openTiles (world);
-
-    // Ensure that start and end points are valid
-    if (!openTiles.isValid (startX, startY))
-    {
-        std::cout << "Start point either is a wall or isn't out of the world bounds" << std::endl;
-        return EXIT_FAILURE;
-    }
-    // Check each neighbor
-    if (!openTiles.isValid (endX, endY))
-    {
-        std::cout << "End point either is a wall or isn't out of the world bounds" << std::endl;
-        return EXIT_FAILURE;
-    }
+    PriorityQueue openTiles (world.getWidth (), world.getHeight ());
 
     // Dijkstra's algorithm
-    openTiles.changeBestCost(startX, startY, 0);
+    openTiles.push (world (startX, startY), {startX, startY}, 0);
 
     std::unordered_map<uint, PathTile> expandedTiles;
     PathTile tile = openTiles.top();
@@ -91,11 +78,51 @@ int main (int args, char* argv[])
     {
         openTiles.pop ();
         expandedTiles[tile.getTile ().id] = tile;
+
         // Check each neighbor
-        openTiles.tryUpdateBestCost (tile.xy ().x + 1, tile.xy ().y, tile); // east
-        openTiles.tryUpdateBestCost (tile.xy ().x, tile.xy ().y + 1, tile); // south
-        openTiles.tryUpdateBestCost (tile.xy ().x - 1, tile.xy ().y, tile); // west
-        openTiles.tryUpdateBestCost (tile.xy ().x, tile.xy ().y - 1, tile); // north
+        Point adjPoint {tile.xy ().x + 1, tile.xy ().y}; // east
+        if (adjPoint.x < world.getWidth() && adjPoint.y < world.getHeight ())
+        {
+            World::tile_t worldTile = world (adjPoint.x, adjPoint.y);
+            if (worldTile.cost != 0 &&
+                expandedTiles.find (worldTile.id) == expandedTiles.end ())
+            {
+                openTiles.tryUpdateBestCost (worldTile, adjPoint, tile);
+            }
+        }
+
+        adjPoint = {tile.xy ().x, tile.xy ().y + 1}; // south
+        if (adjPoint.x < world.getWidth() && adjPoint.y < world.getHeight ())
+        {
+            World::tile_t worldTile = world (adjPoint.x, adjPoint.y);
+            if (worldTile.cost != 0 &&
+                expandedTiles.find (worldTile.id) == expandedTiles.end ())
+            {
+                openTiles.tryUpdateBestCost (worldTile, adjPoint, tile);
+            }
+        }
+
+        adjPoint = {tile.xy ().x - 1, tile.xy ().y}; // west
+        if (adjPoint.x < world.getWidth() && adjPoint.y < world.getHeight ())
+        {
+            World::tile_t worldTile = world (adjPoint.x, adjPoint.y);
+            if (worldTile.cost != 0 &&
+                expandedTiles.find (worldTile.id) == expandedTiles.end ())
+            {
+                openTiles.tryUpdateBestCost (worldTile, adjPoint, tile);
+            }
+        }
+
+        adjPoint = {tile.xy ().x, tile.xy ().y - 1}; // north
+        if (adjPoint.x < world.getWidth() && adjPoint.y < world.getHeight ())
+        {
+            World::tile_t worldTile = world (adjPoint.x, adjPoint.y);
+            if (worldTile.cost != 0 &&
+                expandedTiles.find (worldTile.id) == expandedTiles.end ())
+            {
+                openTiles.tryUpdateBestCost (worldTile, adjPoint, tile);
+            }
+        }
 
         tile = openTiles.top ();
     }


### PR DESCRIPTION
Before the PriorityQueue was parsing the entire world before being used in the algorithms and now the algorithms push the new opened tiles to the PriorityQueue instead giving a very large performance boost.